### PR TITLE
Allow no icon to be used

### DIFF
--- a/sunrise.php
+++ b/sunrise.php
@@ -87,7 +87,7 @@ if ( !class_exists( 'Sunrise6' ) ) {
 					'menu_title'  => __( 'Plugin Settings', $this->config['textdomain'] ),
 					'capability'  => 'manage_options',
 					'slug'        => $this->config['slug'],
-					'icon_url'    => admin_url( 'images/wp-logo.png' ),
+					'icon_url'    => '',
 					'position'    => '81.' . rand( 0, 99 ),
 					'url'         => '',
 					'options'     => array()


### PR DESCRIPTION
Allow setting `icon_url` to be empty so the default icon gets used. Using WordPress 3.9+.
